### PR TITLE
FIxed missing signal import

### DIFF
--- a/util.py
+++ b/util.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import select
 import json
+import signal
 import threading
 
 import typing


### PR DESCRIPTION
Fixed undefined name 'signal'

Bento Output:

```
flake8 ambiguous-variable-name https://lintlyci.github.io/Flake8Rules/rules/E741.html 
     > util.py:100                                                                    
     ╷                                                                                
  100│   l = h.read(4096)                                                             
     ╵
     = ambiguous variable name 'l'

flake8 ambiguous-variable-name https://lintlyci.github.io/Flake8Rules/rules/E741.html
     > util.py:107
     ╷
  107│   l = h.readline()
     ╵
     = ambiguous variable name 'l'

flake8 ambiguous-variable-name https://lintlyci.github.io/Flake8Rules/rules/E741.html
     > util.py:129
     ╷
  129│   l = min(getattr(select,'PIPE_BUF',512), len(stdin)) # write with select.PIPE_BUF bytes or less should not block
     ╵
     = ambiguous variable name 'l'

flake8 undefined-name https://lintlyci.github.io/Flake8Rules/rules/F821.html
     > util.py:187
     ╷
  187│   p.send_signal(signal.SIGUSR1)
     ╵
     = undefined name 'signal'
```